### PR TITLE
Always add an extra newline to end of a heredoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 function heredoc(fn) {
-  return fn.toString().split('\n').slice(1,-1).join('\n')
+  return fn.toString().split('\n').slice(1,-1).join('\n') + '\n'
 }
 
 module.exports = heredoc


### PR DESCRIPTION
A heredoc should be treated like a block wherein further string concatenation begins on a new line. This should be helpful in most if not all cases.
