### PR TITLE
Replace \s with [ \t]

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,17 @@
     return fn.toString().split('\n').slice(1,-1).join('\n') + '\n'
   }
 
-  var stripPattern = /^\s*(?=[^\s]+)/mg
+  var stripPattern = /^[ \t]*(?=[^\s]+)/mg
   // normalizes leading indentation https://github.com/jden/heredoc/pull/6
   heredoc.strip = function(fn) {
     var text = heredoc(fn)
-    
+
     var indentLen = text.match(stripPattern)
                                  .reduce(function (min, line) {
       return Math.min(min, line.length)
     }, Infinity)
 
-    var indent = new RegExp('^\\s{' + indentLen + '}', 'mg')
+    var indent = new RegExp('^[ \\t]{' + indentLen + '}', 'mg')
     return indentLen > 0
       ? text.replace(indent, '')
       : text

--- a/test/test.heredoc.strip.js
+++ b/test/test.heredoc.strip.js
@@ -56,7 +56,22 @@ describe('heredoc.strip', function() {
       '</ul>',
       ''
     ])
-   
+
+  })
+
+  it('keeps empty lines', function() {
+    var text = heredoc.strip(function() {/*
+      # Title
+
+      Hi there.
+    */})
+    text.split('\n').should.deep.equal([
+      '# Title',
+      '',
+      'Hi there.',
+      ''
+    ])
+
   })
 
 })


### PR DESCRIPTION
`\s` matches a lot of characters, including `\n`, which makes cases like this fail:

```js
var markdown = heredoc.strip(function() {/*
  # Title

  Hi there.
*/})
``` 

The expected result would be:

```
# Title

Hi there.
```

But currently `heredoc.strip` returns:

```
# Title
 Hi there.
```

References:
- https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp