### PR TITLE
Added the ability to have params parsed inside of heredoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can also pass params to heredoc:
 ```js
 var text = heredoc.strip(function() {/*
       My first name is {firstname} and my last name is {lastname}
-    */})
+    */}, {firstname: "Andrew", lastname: "Schools"})
 ```
 
 will result in:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ will result in:
 
 ```
 
+You can also pass params to heredoc:
+
+```js
+var text = heredoc.strip(function() {/*
+      My first name is {firstname} and my last name is {lastname}
+    */})
+```
+
+will result in:
+
+```
+My first name is Andrew and my last name is Schools
+
+```
+
 ## AMD
 
 `heredoc` defines itself as an AMD module for use in AMD environments.
@@ -51,7 +66,7 @@ will result in:
     $ npm install heredoc
 
 ## contributors
-  
+
   - jden <jason@denizac.org>
   - Jason Kuhrt <jasonkuhrt@me.com>
   - Guy Bedford <guybedford@gmail.com>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 !function (root) {
 
-  function heredoc(fn) {
-    return fn.toString().split('\n').slice(1,-1).join('\n') + '\n'
+  function heredoc(fn, values) {
+    var data = fn.toString().split('\n').slice(1,-1).join('\n') + '\n';
+
+    for (var key in values) {
+      data = data.replace("{"+key+"}", values[key]);
+    }
+
+    return data;
   }
 
   var stripPattern = /^[ \t]*(?=[^\s]+)/mg

--- a/sample.js
+++ b/sample.js
@@ -9,5 +9,6 @@ will
   pre-formatted
     multiline text
 (kinda like html <pre>)
-*/})
+and can also parse params sent to it like this {param1} and this {param2}
+*/}, {param1:"test1", param2:"test2"})
 console.log(str)

--- a/test/test.heredoc.js
+++ b/test/test.heredoc.js
@@ -22,3 +22,24 @@ will
     lines[lines.length - 2].should.equal('(kinda like html <pre>)')
   })
 })
+
+  it('should be able to define string in function with params parsed in it', function() {
+    var text = heredoc(function () {/*
+within this comment block,
+any text
+will
+  be
+    treated
+      as
+  pre-formatted
+    multiline text
+(kinda like html <pre>)
+and the params sent should be parsed like this: {param1} and this: {param2}
+    */}, {param1:"test1", param2:"test2"})
+    var lines = text.split('\n')
+
+    lines[0].should.equal('within this comment block,')
+    lines[lines.length - 3].should.equal('(kinda like html <pre>)')
+    lines[lines.length-1].should.equal('and the params sent should be parsed like this: test1 and this: test2')
+  })
+})


### PR DESCRIPTION
An example of this:

var text = heredoc.strip(function() {/*
My first name is {firstname} and my last name is {lastname}
*/}, {firstname: "Andrew", lastname: "Schools"})