### PR TITLE
Upgrade: use oceanifier@4.0.1 to simplify test/runner.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+tmp
 
 *.log

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "mocha": "~2.2.5",
-    "oceanifier": "~4.0.1",
+    "oceanifier": "~4.0.2",
     "opener": "^1.4.1",
     "should": "~6.0.3",
     "standard": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && mocha",
-    "test-browser": "echo open http://localhost:5000/test/runner.html && oceanify serve"
+    "test-browser": "echo open http://localhost:5000/test/runner.html && ocean serve"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "mocha": "~2.2.5",
-    "oceanifier": "~3.0.1",
+    "oceanifier": "~4.0.1",
     "opener": "^1.4.1",
     "should": "~6.0.3",
     "standard": "^4.0.1"

--- a/test/runner.html
+++ b/test/runner.html
@@ -8,16 +8,6 @@
 <body>
   <div id="mocha"></div>
   <script src="/node_modules/mocha/mocha.js"></script>
-  <script src="/node_modules/should/should.js"></script>
-  <script src="http://amo.alicdn.com/L1/377/101010/sea.js"></script>
-  <script src="/config.js"></script>
-  <script>
-    /* eslint-disable */
-    mocha.ui('bdd')
-    define('should', should)  // use the pre-build version of should
-    seajs.use('heredoc/test/runner', function() {
-      mocha.run()
-    })
-  </script>
+  <script src="/runner.js"></script>
 </body>
 </html>

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,4 +1,8 @@
 'use strict'
 
+mocha.setup('bdd')
+
 require('./test.heredoc')
 require('./test.heredoc.strip')
+
+mocha.run()

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,8 +1,9 @@
 'use strict'
+/* globals mocha */
 
-mocha.setup('bdd')
+if (typeof mocha !== 'undefined') mocha.setup('bdd')
 
 require('./test.heredoc')
 require('./test.heredoc.strip')
 
-mocha.run()
+if (typeof mocha !== 'undefined') mocha.run()


### PR DESCRIPTION
I've refactored and enhanced oceanifier a lot. With oceanifier@4.0.1, the `test/runner.html` can be simplified drastically. 
